### PR TITLE
docs: Add running instruction in main page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Exercise #4: Velocity estimation
 
 The quickest way to get started without manual installation is to use
 [GitHub Codespaces](https://github.com/features/codespaces) - "a development environment that's hosted in the cloud". This allows you to run the workshop exercises directly in your browser without needing to set up a local environment.
-In order to access the Codespace, you need to register an account with [GitHub](github.com).
+In order to access the Codespace, you need to register an account with [GitHub](https://github.com).
 
 :::{important}
 When clicking the button below, if you have any current codespace,

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,10 @@ In order to access the Codespace, you need to register an account with [GitHub](
 When clicking the button below, if you have any current codespace,
 we recommend deleting it to ensure you have the latest
 changes from the workshop repository.
+
+Additionally, once codespace is rendered,
+please wait until the `README.md` file is loaded
+to ensure that setup is complete.
 :::
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/seafloor-geodesy/gnatss-workshop?quickstart=1)

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,3 +59,19 @@ Exercise #2: Flagging GNSS-A travel time residuals
 Exercise #3: Exploring GNSS-A metadata
 
 Exercise #4: Velocity estimation
+
+## Running the Exercises
+
+The quickest way to get started without manual installation is to use
+[GitHub Codespaces](https://github.com/features/codespaces) - "a development environment that's hosted in the cloud". This allows you to run the workshop exercises directly in your browser without needing to set up a local environment.
+In order to access the Codespace, you need to register an account with [GitHub](github.com).
+
+:::{important}
+When clicking the button below, if you have any current codespace,
+we recommend deleting it to ensure you have the latest
+changes from the workshop repository.
+:::
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/seafloor-geodesy/gnatss-workshop?quickstart=1)
+
+☝️ Click the button above to go to options window to launch a GitHub Codespace.


### PR DESCRIPTION
This pull request updates the documentation for the GNSS-A workshop by adding a new section on running the exercises using GitHub Codespaces. The change introduces a user-friendly way to get started with the exercises without requiring manual setup.

### Documentation Update:

* Added a "Running the Exercises" section in `docs/index.md`, explaining how to use GitHub Codespaces to run the workshop exercises directly in a browser. This includes a link to the Codespaces page, a recommendation to delete existing Codespaces for updates, and a button to launch a new Codespace.