### PR TITLE
chore: added starter code blocks to exercises

### DIFF
--- a/docs/exercise-1.ipynb
+++ b/docs/exercise-1.ipynb
@@ -550,7 +550,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "output = run_gnatss(\n",
+    "    config_yaml,\n",
+    "    distance_limit=distance_limit,\n",
+    "    from_cache=,\n",
+    "    remove_outliers=\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/docs/exercise-2.ipynb
+++ b/docs/exercise-2.ipynb
@@ -826,10 +826,42 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = run_gnatss(\n",
+    "    config_yaml,\n",
+    "    distance_limit=distance_limit,\n",
+    "    residual_limit=,\n",
+    "    residual_range_limit=,\n",
+    "    skip_posfilter=skip_posfilter\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "2) There are four other data sets collected at this array between the years 2018-2023. Try to process these data and flag them on your own. Like with the 2024 survey, each of these data sets has already been preprocessed so you only have to run the GNATSS solver module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config_yaml = \"../data/exercise-2/NCB1_2023_config.yaml\"\n",
+    "\n",
+    "output = run_gnatss(\n",
+    "    config_yaml,\n",
+    "    distance_limit=distance_limit,\n",
+    "    residual_limit=,\n",
+    "    residual_range_limit=,\n",
+    "    skip_posfilter=skip_posfilter\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses issue #44 by adding (incomplete) starter code blocks to the problems in exercises 1&2. Exercise 3&4 are meant as repositories and do not include problem sets, so they are not modified here.