### PR TITLE
ci: Add vscode settings and install all deps

### DIFF
--- a/.devcontainer/onCreate.sh
+++ b/.devcontainer/onCreate.sh
@@ -4,5 +4,5 @@
 set -e
 
 sudo chown vscode .pixi
-pixi install
+pixi install --all
 pixi shell-hook >> ${VSCODE_HOME}/.bashrc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.pixi/envs/default/bin/python",
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+}


### PR DESCRIPTION
Due to some quirks in the python environments.. there's even an issue 4 days ago: https://github.com/microsoft/vscode-python/issues/25351. Setting the default interpreter path as well as the default env manager settings for vscode so it can find the environment right away. Additionally, install all pixi environments so that pixi extension doesn't break as well.