### PR TITLE
docs: Update release text for the Codespaces button to link

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,9 +49,9 @@ The quickest way to get started without manual installation is to use
 [GitHub Codespaces](https://github.com/features/codespaces) - "a development environment that's hosted in the cloud". This allows you to run the workshop exercises directly in your browser without needing to set up a local environment.
 In order to access the Codespace, you need to register an account with [GitHub](github.com)
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/seafloor-geodesy/gnatss-workshop?quickstart=1)
+[Launch GitHub Codespaces](https://codespaces.new/seafloor-geodesy/gnatss-workshop?quickstart=1)
 
-☝️ Click the button above to go to options window to launch a GitHub Codespace.
+☝️ Click the link above to go to options window to launch a GitHub Codespace.
 
 ## List of Exercises
 


### PR DESCRIPTION
This pull request makes a minor update to the `RELEASE.md` documentation to improve clarity and consistency in how users are directed to launch a GitHub Codespace.

- Replaced the "Open in GitHub Codespaces" badge/button with a plain text link labeled "Launch GitHub Codespaces" and updated the accompanying instructional text for clarity.